### PR TITLE
Add new brilliancy condition

### DIFF
--- a/src/lib/analysis.ts
+++ b/src/lib/analysis.ts
@@ -213,6 +213,7 @@ async function analyse(positions: EvaluatedPosition[]): Promise<Report> {
                                 // If the capture of the piece with the current attacker leads to
                                 // a piece of greater or equal value being hung (if attacker is pinned)
                                 let attackerPinned = false;
+                                let isPinnedAttackerQueen = false;
                                 for (let row of captureTestBoard.board()) {
                                     for (let enemyPiece of row) {
                                         if (!enemyPiece) continue;
@@ -220,8 +221,11 @@ async function analyse(positions: EvaluatedPosition[]): Promise<Report> {
                 
                                         if (
                                             isPieceHanging(position.fen, captureTestBoard.fen(), enemyPiece.square)
-                                            && pieceValues[enemyPiece.type] >= Math.max(...sacrificedPieces.map(sack => pieceValues[sack.type]))
                                         ) {
+                                            if (enemyPiece.type == "q" ) {
+                                                isPinnedAttackerQueen = true
+                                            }
+
                                             attackerPinned = true;
                                             break;
                                         }
@@ -230,7 +234,12 @@ async function analyse(positions: EvaluatedPosition[]): Promise<Report> {
                                 }
 
                                 // If the capture of the piece leads to mate in 1
-                                if (!attackerPinned && !captureTestBoard.moves().some(move => move.endsWith("#"))) {
+                                if (attackerPinned && captureTestBoard.moves().some(move => move.endsWith("#"))) {
+                                    anyPieceViablyCapturable = true;
+                                    break;
+                                }
+
+                                if (attackerPinned && isPinnedAttackerQueen && currentBoard.isCheck()) {
                                     anyPieceViablyCapturable = true;
                                     break;
                                 }


### PR DESCRIPTION
* Add new brilliancy condition for when check leaves a hanging queen. Adding the most specific case here with the idea you can build up a bunch of cases and generalise from there if need be.
* Correct checkmate brilliancy condition (seems it was inverted?) `if (attackerPinned && captureTestBoard.moves().some(move => move.endsWith("#"))) {`

This move shows as brilliant on chess.com but not here:
Move 22 Bxh2+ in the PGN:
```
1. d4 e5 2. dxe5 Nc6 3. Nf3 f6 4. exf6 Nxf6 5. e3 d5 6. Nd4 Bd7 7. Be2 Bd6 8.
O-O Qe7 9. Re1 O-O-O 10. c3 Rdf8 11. Na3 Ne4 12. f3 Qe5 13. f4 Qf6 14. Qa4 Kb8
15. Qb3 g5 16. Ba6 b6 17. Rf1 Nc5 18. Qxd5 Nxa6 19. Nxc6+ Bxc6 20. Qxc6 Nc5 21.
Bd2 Nd3 22. fxg5 Bxh2+ 23. Kxh2 Qxc6 24. Rxf8+ Rxf8 25. b3 Rf2 26. Bc1 Qxg2# 0-1
```
![image](https://github.com/WintrCat/freechess/assets/28284434/cacd63f4-9f9c-406b-8430-737d3e9fe98b)
