### PR TITLE
Add Dockerfile to run game review in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM alpine:latest
+FROM node:20
 
 COPY * /app/
 
 WORKDIR /app/
 
-RUN apk update
-RUN apk add nodejs
 RUN npm install typescript
 
 ENV PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ COPY * /app/
 
 WORKDIR /app/
 
-RUN apt-get update
-RUN apt-get install nodejs
+RUN apk update
+RUN apk add nodejs
 RUN npm install typescript
 
 ENV PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM Alpine:latest
+FROM alpine:latest
 
 COPY * /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM Alpine:latest
+
+COPY * /app/
+
+WORKDIR /app/
+
+RUN apt-get update
+RUN apt-get install nodejs
+RUN npm install typescript
+
+ENV PORT=80
+# ENV RECAPTCHA_SECRET=<secret>
+
+EXPOSE 80/tcp
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM node:20
 
-COPY * /app/
+LABEL name="wintrcat/freechess"
+LABEL version="1.0.0"
 
-WORKDIR /app/
+WORKDIR /usr/app/
 
-RUN npm install typescript
+COPY . .
 
-ENV PORT=80
-# ENV RECAPTCHA_SECRET=<secret>
+RUN npm install -g typescript
+RUN npm i
+
+ENV PORT 80
 
 EXPOSE 80/tcp
 
-CMD ["npm", "start"]
+ENTRYPOINT ["npm", "start"]

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Enter a game by its PGN or pick a game from your Chess.com / Lichess.org account
 - Create a file called `.env` in the root directory of the project.
 - Choose a port for the webserver by adding `PORT=<some port>` to the file.
 - If you want to use a CAPTCHA:
-    - add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
+    - Add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
     - Open `src/public/pages/report/index.html`, find `data-sitekey` and replace the value with your reCAPTCHA public site key
 - Run `npm start` to compile TypeScript and start the webserver.
 
@@ -34,7 +34,7 @@ Enter a game by its PGN or pick a game from your Chess.com / Lichess.org account
 - Open the root directory of the project in a terminal.
 - Create a file called `.env` in the root directory of the project.
 - If you want to use a CAPTCHA:
-    - add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
+    - Add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
     - Open `src/public/pages/report/index.html`, find `data-sitekey` and replace the value with your reCAPTCHA public site key
 - Run `sudo docker build . -t freechess` to build the image
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Enter a game by its PGN or pick a game from your Chess.com / Lichess.org account
 - If you want to use a CAPTCHA:
     - add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
     - Open `src/public/pages/report/index.html`, find `data-sitekey` and replace the value with your reCAPTCHA public site key
-- Run `sudo docker build -t freechess ./` to build the image
+- Run `sudo docker build . -t freechess` to build the image
 
 ### Start a Docker container with the freechess image
 - Run `sudo docker run -d -P freechess`

--- a/readme.md
+++ b/readme.md
@@ -15,13 +15,32 @@ Enter a game by its PGN or pick a game from your Chess.com / Lichess.org account
 - Run `npm i` to install all of the necessary dependencies.
 - Create a file called `.env` in the root directory of the project.
 - Choose a port for the webserver by adding `PORT=<some port>` to the file.
-- If you want to use a CAPTCHA, add your client secret as `RECAPTCHA_SECRET=<secret>`
+- If you want to use a CAPTCHA:
+    - add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
+    - Open `src/public/pages/report/index.html`, find `data-sitekey` and replace the value with your reCAPTCHA public site key
 - Run `npm start` to compile TypeScript and start the webserver.
 
 ### NPM Scripts
 - `npm start` - Compiles TypeScript and starts the webserver.
 - `npm run build` - Compiles TypeScript.
 - `npm run test` - Generates reports from some sample evaluations for classification testing at `src/test/reports`.
+
+## Running in Docker
+### Prerequisites
+- Docker installed on the server
+
+### Build a Docker image
+- Download the source code using `git clone` or download as ZIP.
+- Open the root directory of the project in a terminal.
+- Create a file called `.env` in the root directory of the project.
+- If you want to use a CAPTCHA:
+    - add your client secret as `RECAPTCHA_SECRET=<secret>` to the .env file
+    - Open `src/public/pages/report/index.html`, find `data-sitekey` and replace the value with your reCAPTCHA public site key
+- Run `sudo docker build -t freechess ./` to build the image
+
+### Start a Docker container with the freechess image
+- Run `sudo docker run -d -P freechess`
+- If you wish to choose the port instead of Docker choosing one for you, replace `-P` with `-p <port>:80`
 
 ## Donate
 I pay to keep my app running and free-to-use for everyone. Any donations are greatly appreciated ❤️


### PR DESCRIPTION
I modified a fork of this project to run in docker on my own server. I believe this small addition would benefit the main project.
### The changes are
- An added Dockerfile which automates building an image that can be run in a container 
- Updates to the readme to document image generation and spinning up a container with the image, and where to add your site key for reCAPTCHA.

The feature simply copies the project into a node 20 docker image and should not require any maintenance independent of the rest of the codebase. Thank you for open sourcing this great little project! Let me know if any changes need to be made or if this is out of scope, this is my first pull request