### PR TITLE
UI Fix: Long opening-name covers move-classification

### DIFF
--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -128,7 +128,10 @@
                         <div class="accuracyHolder">
                         <h2 id="accuracies-title" class="white">Accuracies<div class="accuracyDiv"><b id="white-accuracy" class="accuracies">100%</b>
                             <b id="black-accuracy" class="accuracies">100%</b></div></h2>
+                            
                         </div>
+
+                        <span id="opening-name" class="white"></span>
     
                         <div id="classification-message-container">
                             <img id="classification-icon" src="/static/media/book.png" height="25">
@@ -140,7 +143,6 @@
                         <div id="engine-suggestions">
                             <h2 id="engine-suggestions-title" class="white">Engine</h2>
                         </div>
-                        <span id="opening-name" class="white"></span>
                     </div>
                 </div>
 

--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="/static/pages/report/styles/reviewpanel.css">
     <link rel="stylesheet" href="/static/pages/report/styles/report.css">
 
-    <link rel="shortcut icon" href="/freechess/src/public/media/favicon-freechess.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="/static/media/favicon-freechess.ico" type="image/x-icon">
 
     <audio id="sound-fx-move" class="sound-fx-board" src="/static/media/move.mp3"></audio>
     <audio id="sound-fx-capture" class="sound-fx-board" src="/static/media/capture.mp3"></audio>
@@ -91,7 +91,7 @@
                     <div id="gameInputContainer2" class="gameInputContainer" >
                         <textarea id="chess-site-username" class="white" spellcheck="false" maxlength="48" placeholder="Username..."></textarea>
                         <button id="fetch-account-games-button" class="usernameVerifyBtn">
-                            <i id="next-move-button" class="usernameVerifyBtnIcon fa-solid fa-arrow-right contol-icons" style="color: #ffffff;"></i>
+                            <i id="fetch-account-games-button-icon" class="usernameVerifyBtnIcon fa-solid fa-arrow-right contol-icons" style="color: #ffffff;"></i>
                         </button>
                     </div>
                 
@@ -124,10 +124,10 @@
 
                     <b id="secondary-message" class="white"></b>
 
-                    <div id="report-cards">
+                    <div id="report-cards" class="show">
                         <div class="accuracyHolder">
-                        <h2 id="accuracies-title" class="white">Accuracies<div class="accuracyDiv"><b id="white-accuracy" class="accuracies">0%</b>
-                            <b id="black-accuracy" class="accuracies">0%</b></div></h2>
+                        <h2 id="accuracies-title" class="white">Accuracies<div class="accuracyDiv"><b id="white-accuracy" class="accuracies">100%</b>
+                            <b id="black-accuracy" class="accuracies">100%</b></div></h2>
                         </div>
     
                         <div id="classification-message-container">

--- a/src/public/pages/report/styles/board.css
+++ b/src/public/pages/report/styles/board.css
@@ -35,7 +35,4 @@
     max-width: 100%;
     width: 720px;
     height: auto;
-
-    border: 2px solid var(--border-color);
-    border-radius: 5px;
 }

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -29,12 +29,12 @@
     border-bottom-right-radius: 0px;
     position: relative;
 }
-
 .accuracyDiv{
     display: flex;
     justify-content: center;
     align-items: center;
     gap: 5px;
+    width: 50%;
 }
 .accuracies{
     border: 2px solid #4caf50;
@@ -120,7 +120,25 @@
     font-size: 18px;
     
 }
+@media (max-width: 1300px){
+    #accuracies-title{
+        font-size: 18px !important;
+    }
 
+    .accuracies{
+        font-size: 18px !important;
+    }
+}
+
+@media (max-width: 1100px){
+    #accuracies-title{
+        font-size: 16px !important;
+    }
+
+    .accuracies{
+        font-size: 16px !important;
+    }
+}
 .engine-suggestion b {
     padding: 0 3px;
     text-align: center;

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -18,7 +18,6 @@
     border-radius: 10px;
     width: 90%;
     text-align: center;
-    margin-bottom: 5px;
     border: 2px solid var(--border-color);
     height: 50px;
     display: flex;
@@ -91,7 +90,7 @@
     flex-direction: column;
     align-items: center;
     border-radius: 10px;
-    margin-top: 25px;
+    margin-top: 10px;
     border: 2px solid var(--border-color);
 
     width: 90%;
@@ -153,9 +152,7 @@
 */
 
 #opening-name {
-    position: absolute;
     left: 5%;
-    top: 50px;
     width: 90%;
     border-radius: 10px;
     background-color: var(--primary-color);

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -62,7 +62,7 @@
     justify-content: center;
     align-items: center;
     gap: 5px;
-    margin-top: 25px;
+    margin-top: 10px;
     width: 90%;
     background-color: var(--primary-color);
     border-radius: 10px;


### PR DESCRIPTION
This pull request addresses an issue where long opening names were obscuring the move classification in the user interface. The fix ensures that both elements remain visible, enhancing the usability and clarity of the interface.

before :
![Screenshot_255](https://github.com/WintrCat/freechess/assets/160760699/5b81722d-a23c-4d01-840e-7a46f8fe13d6)


after : 
![Screenshot_254](https://github.com/WintrCat/freechess/assets/160760699/f1bfbf8b-a7f0-4424-bf1f-a72b11ee94dc)
