### PR TITLE
Add support for fetching lichess games against computer

### DIFF
--- a/src/public/pages/report/scripts/loadgame.ts
+++ b/src/public/pages/report/scripts/loadgame.ts
@@ -16,6 +16,16 @@ function updateGamesPeriod() {
     $("#game-select-period").html(`${padMonth(gamesPeriod.month)}/${gamesPeriod.year}`);
 }
 
+function getPlayersString(game: Game) {
+    if (game.white.aiLevel) {
+        return `AI level ${game.white.aiLevel} vs. ${game.black.username} (${game.black.rating})`;
+    } else if (game.black.aiLevel) {
+        return `${game.white.username} (${game.white.rating}) vs. AI level ${game.black.aiLevel}`;
+    } else {
+        return `${game.white.username} (${game.white.rating}) vs. ${game.black.username} (${game.black.rating})`;
+    }
+}
+
 function generateGameListing(game: Game): JQuery<HTMLDivElement> {
 
     let listingContainer = $<HTMLDivElement>("<div>");
@@ -30,7 +40,7 @@ function generateGameListing(game: Game): JQuery<HTMLDivElement> {
     timeClass.html(game.timeClass.replace(/^./, game.timeClass.charAt(0).toUpperCase()));
 
     let players = $("<span>");
-    players.html(`${game.white.username} (${game.white.rating}) vs. ${game.black.username} (${game.black.rating})`);
+    players.html(getPlayersString(game));
 
     listingContainer.append(timeClass);
     listingContainer.append(players);
@@ -112,12 +122,14 @@ async function fetchLichessGames(username: string) {
         for (let game of games) {
             let gameListing = generateGameListing({
                 white: {
-                    username: game.players.white.user.name,
-                    rating: game.players.white.rating
+                    username: game.players.white.user?.name,
+                    rating: game.players.white.rating,
+                    aiLevel: game.players.white.aiLevel
                 },
                 black: {
-                    username: game.players.black.user.name,
-                    rating: game.players.black.rating
+                    username: game.players.black.user?.name,
+                    rating: game.players.black.rating,
+                    aiLevel: game.players.black.aiLevel
                 },
                 timeClass: game.speed,
                 pgn: game.pgn

--- a/src/public/pages/report/scripts/types.ts
+++ b/src/public/pages/report/scripts/types.ts
@@ -5,7 +5,8 @@ declare class grecaptcha {
 
 interface Profile {
     username: string,
-    rating: string
+    rating: string,
+    aiLevel?: string
 }
 
 interface Game {


### PR DESCRIPTION
fixes a bug where it would throw an error "No games found." if you have at least 1 game against computer at lichess. Now it displays it like this:
![firefox_0ejdTiAyQn](https://github.com/WintrCat/freechess/assets/132449003/1b0e3a2c-59e6-4c11-b643-824c5fd8765d)
![firefox_MsoB1zccon](https://github.com/WintrCat/freechess/assets/132449003/00f30fba-a593-44d7-a479-8f3f08f2d017)
Used to be like this:
![firefox_nlAoMDegYJ](https://github.com/WintrCat/freechess/assets/132449003/22c4f4e4-f277-478b-b2c7-fd1b4b863a17)
