### PR TITLE
feat: add classification count for analysis

### DIFF
--- a/src/lib/analysis.ts
+++ b/src/lib/analysis.ts
@@ -344,12 +344,40 @@ async function analyse(positions: EvaluatedPosition[]): Promise<Report> {
             maximum: 0
         }
     };
+    const classifications = {
+        white: {
+            brilliant: 0,
+            great: 0,
+            best: 0,
+            excellent: 0,
+            good: 0,
+            inaccuracy: 0,
+            mistake: 0,
+            blunder: 0,
+            book: 0,
+            forced: 0,
+        },
+        black: {
+            brilliant: 0,
+            great: 0,
+            best: 0,
+            excellent: 0,
+            good: 0,
+            inaccuracy: 0,
+            mistake: 0,
+            blunder: 0,
+            book: 0,
+            forced: 0,
+        }
+    };
 
     for (let position of positions.slice(1)) {
         const moveColour = position.fen.includes(" b ") ? "white" : "black";
 
         accuracies[moveColour].current += classificationValues[position.classification!];
         accuracies[moveColour].maximum++;
+
+        classifications[moveColour][position.classification!] += 1;
     }
 
     // Return complete report
@@ -358,6 +386,7 @@ async function analyse(positions: EvaluatedPosition[]): Promise<Report> {
             white: accuracies.white.current / accuracies.white.maximum * 100,
             black: accuracies.black.current / accuracies.black.maximum * 100
         },
+        classifications,
         positions: positions
     };
 

--- a/src/lib/types/Classification.ts
+++ b/src/lib/types/Classification.ts
@@ -1,0 +1,3 @@
+import { Classification } from "../classification";
+
+export interface ClassificationCount extends Record<Classification, number> {}

--- a/src/lib/types/Report.ts
+++ b/src/lib/types/Report.ts
@@ -1,3 +1,4 @@
+import { ClassificationCount } from "./Classification"
 import { EvaluatedPosition } from "./Position"
 
 export default interface Report {
@@ -5,5 +6,9 @@ export default interface Report {
         white: number,
         black: number
     },
+    classifications: {
+        white: ClassificationCount,
+        black: ClassificationCount,
+    }
     positions: EvaluatedPosition[]
 }

--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -159,7 +159,7 @@
                     </div>
 
                     <div id="classification-count-tooltip-container">
-                        <div id="classification-count-tooltip-message">* See your analysis classification</div>
+                        <div id="classification-count-tooltip-message">* See your classifications</div>
                         <div id="classification-count-container"></div>
                     </div>
 

--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -158,7 +158,10 @@
                         </h2>
                     </div>
 
-                    <div id="classification-count-container"></div>
+                    <div id="classification-count-tooltip-container">
+                        <div id="classification-count-tooltip-message">* See your analysis classification</div>
+                        <div id="classification-count-container"></div>
+                    </div>
 
                     <div id="classification-message-container">
                         <img id="classification-icon" src="/static/media/book.png" height="25">

--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -158,6 +158,8 @@
                         </h2>
                     </div>
 
+                    <div id="classification-count-container"></div>
+
                     <div id="classification-message-container">
                         <img id="classification-icon" src="/static/media/book.png" height="25">
                         <b id="classification-message"></b>

--- a/src/public/pages/report/scripts/analysis.ts
+++ b/src/public/pages/report/scripts/analysis.ts
@@ -230,6 +230,9 @@ function loadReportCards() {
         $("#white-accuracy").html(`${reportResults.accuracies.white.toFixed(1)}%`);
         $("#black-accuracy").html(`${reportResults.accuracies.black.toFixed(1)}%`);
 
+        // Initialize classification container for next analysis
+        $("#classification-count-container").empty();
+
         // Make classification count section
         for (const classification of Object.keys(reportResults.classifications.white)) {
             if (classification === "book" || classification === "forced") continue;

--- a/src/public/pages/report/scripts/analysis.ts
+++ b/src/public/pages/report/scripts/analysis.ts
@@ -225,12 +225,61 @@ function loadReportCards() {
 
     // Reveal report cards and update accuracies
     $("#report-cards").css("display", "flex");
-    $("#white-accuracy").html(
-        `${reportResults?.accuracies.white.toFixed(1) ?? "100"}%`,
-    );
-    $("#black-accuracy").html(
-        `${reportResults?.accuracies.black.toFixed(1) ?? "100"}%`,
-    );
+
+    if (!!reportResults) {
+        $("#white-accuracy").html(`${reportResults.accuracies.white.toFixed(1)}%`);
+        $("#black-accuracy").html(`${reportResults.accuracies.black.toFixed(1)}%`);
+
+        // Make classification count section
+        for (const classification of Object.keys(reportResults.classifications.white)) {
+            if (classification === "book" || classification === "forced") continue;
+
+            const classificationRow = $("<div>").prop({
+                class: "classification-count-row"
+            });
+        
+            // Create white's classification count
+            const whiteClassificationCount = $("<div>").prop({
+                class: "classification-count-white"
+            }).css({
+                color: classificationColours[classification]
+            }).html(`${reportResults.classifications.white[classification as Classifications]}`);
+
+            // Create black's classification count
+            const blackClassificationCount = $("<div>").prop({
+                class: "classification-count-black"
+            }).css({
+                color: classificationColours[classification]
+            }).html(`${reportResults.classifications.black[classification as Classifications]}`);
+
+
+            // Create classification icon and message
+            const classificationContent = $("<div>").prop({
+                class: "classification-count-content"
+            });
+            $(classificationIcons[classification]!).appendTo(classificationContent);
+            $("<div>").html(`${classification}`)
+            .css({
+                color: classificationColours[classification]
+            }).appendTo(classificationContent);
+
+
+            // Add white's classification count
+            whiteClassificationCount.appendTo(classificationRow);
+
+            // Add classification icon and message
+            classificationContent.appendTo(classificationRow);
+
+            // Add black's classification count
+            blackClassificationCount.appendTo(classificationRow);
+
+            // Insert classification row
+            classificationRow.appendTo("#classification-count-container");
+        }
+    } else {
+        $("#black-accuracy").html("100%");
+        $("#white-accuracy").html("100%");
+    }
 
     // Remove progress bar and any status message
     $("#evaluation-progress-bar").css("display", "none");

--- a/src/public/pages/report/scripts/types.ts
+++ b/src/public/pages/report/scripts/types.ts
@@ -49,10 +49,29 @@ interface Position {
     opening?: string
 }
 
+type Classifications = 
+    "brilliant" |
+    "great"|
+    "best"|
+    "excellent"|
+    "good"|
+    "inaccuracy"|
+    "mistake"|
+    "blunder"|
+    "book"|
+    "forced";
+
+interface ClassificationCount extends Record<Classifications, number> {}
+
+
 interface Report {
     accuracies: {
         white: number,
         black: number
+    },
+    classifications: {
+        white: ClassificationCount,
+        black: ClassificationCount
     },
     positions: Position[]
 }

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -72,6 +72,14 @@
     font-style: italic;
     text-decoration: underline;
     font-weight: bold;
+
+    cursor: pointer;
+    animation: classification-count-tooltip-message-pulse 1s infinite ease-in-out alternate;
+}
+
+@keyframes classification-count-tooltip-message-pulse {
+  from { transform: scale(0.95); }
+  to { transform: scale(1.0); }
 }
 
 #classification-count-container {

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -74,13 +74,8 @@
     font-weight: bold;
 
     cursor: pointer;
-    animation: classification-count-tooltip-message-pulse 1s infinite ease-in-out alternate;
 }
 
-@keyframes classification-count-tooltip-message-pulse {
-  from { transform: scale(0.95); }
-  to { transform: scale(1.0); }
-}
 
 #classification-count-container {
     visibility: hidden;
@@ -103,9 +98,11 @@
     #classification-count-tooltip-container {
         margin-top: 40px;
     }
+
     #classification-count-tooltip-message {
         font-size: 15px;
     }
+
     #classification-count-container {
         top: 112px;
     }
@@ -115,9 +112,11 @@
     #classification-count-tooltip-container {
         margin-top: 40px;
     }
+
     #classification-count-tooltip-message {
         font-size: 15px;
     }
+
     #classification-count-container {
         top: 112px;
     }
@@ -129,9 +128,11 @@
     #classification-count-tooltip-container {
         margin-top: 48px;
     }
+
     #classification-count-tooltip-message {
         font-size: 11px;
     }
+
     #classification-count-container {
         top: 116px;
     }
@@ -150,11 +151,16 @@
     align-items: center;
 }
 
-.classification-count-content > img {
+.classification-count-content>img {
     height: 15px;
 }
 
-#classification-count-tooltip-message:hover + #classification-count-container {
+#classification-count-tooltip-message:hover {
+    transition: color 0.25s ease-in-out;
+    color: #abe7ad;
+}
+
+#classification-count-tooltip-message:hover+#classification-count-container {
     visibility: visible;
 }
 

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -57,21 +57,76 @@
 /*
     CLASSIFICATION COUNT
 */
+#classification-count-tooltip-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 90%;
+
+    color: #4caf50;
+}
+
+#classification-count-tooltip-message {
+    font-size: 15px;
+    font-style: italic;
+    text-decoration: underline;
+    font-weight: bold;
+}
+
 #classification-count-container {
+    visibility: hidden;
+    position: absolute;
+
     display: flex;
     align-items: center;
     border-radius: 10px;
-    margin-top: 40px;
     border: 2px solid var(--border-color);
-
-    width: 90%;
-    color: white;
-
     background-color: var(--primary-color);
+    width: 60%;
+
+    color: white;
     flex-direction: column;
-    gap: 2px;
-    
     font-size: 13px;
+    gap: 2px;
+}
+
+@media (min-width: 1537px) {
+    #classification-count-tooltip-container {
+        margin-top: 40px;
+    }
+    #classification-count-tooltip-message {
+        font-size: 15px;
+    }
+    #classification-count-container {
+        top: 112px;
+    }
+}
+
+@media (max-width: 1536px) {
+    #classification-count-tooltip-container {
+        margin-top: 40px;
+    }
+    #classification-count-tooltip-message {
+        font-size: 15px;
+    }
+    #classification-count-container {
+        top: 112px;
+    }
+}
+
+
+
+@media (max-width: 380px) {
+    #classification-count-tooltip-container {
+        margin-top: 48px;
+    }
+    #classification-count-tooltip-message {
+        font-size: 11px;
+    }
+    #classification-count-container {
+        top: 116px;
+    }
 }
 
 .classification-count-row {
@@ -91,6 +146,10 @@
     height: 15px;
 }
 
+#classification-count-tooltip-message:hover + #classification-count-container {
+    visibility: visible;
+}
+
 /*
     CLASSIFICATION MESSAGE
     e.g "Nd4 is a great move"
@@ -101,7 +160,7 @@
     justify-content: center;
     align-items: center;
     gap: 5px;
-    margin-top: 6px;
+    margin-top: 14px !important;
     width: 90%;
     background-color: var(--primary-color);
     border-radius: 10px;
@@ -129,7 +188,7 @@
     flex-direction: column;
     align-items: center;
     border-radius: 10px;
-    margin-top: 6px;
+    margin-top: 14px !important;
     border: 2px solid var(--border-color);
 
     width: 90%;
@@ -183,4 +242,22 @@
     padding: 5px 10px;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+}
+
+@media (max-width: 1026px) {
+    #opening-name {
+        font-size: 15px;
+    }
+}
+
+@media (max-width: 999px) {
+    #opening-name {
+        font-size: 14px;
+    }
+}
+
+@media (max-width: 380px) {
+    #opening-name {
+        font-size: 12px;
+    }
 }

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -55,6 +55,43 @@
 }
 
 /*
+    CLASSIFICATION COUNT
+*/
+#classification-count-container {
+    display: flex;
+    align-items: center;
+    border-radius: 10px;
+    margin-top: 40px;
+    border: 2px solid var(--border-color);
+
+    width: 90%;
+    color: white;
+
+    background-color: var(--primary-color);
+    flex-direction: column;
+    gap: 2px;
+    
+    font-size: 13px;
+}
+
+.classification-count-row {
+    display: flex;
+    justify-content: space-between;
+    width: 80%;
+}
+
+.classification-count-content {
+    display: flex;
+    gap: 6px;
+    font-weight: bold;
+    align-items: center;
+}
+
+.classification-count-content > img {
+    height: 15px;
+}
+
+/*
     CLASSIFICATION MESSAGE
     e.g "Nd4 is a great move"
 */
@@ -64,7 +101,7 @@
     justify-content: center;
     align-items: center;
     gap: 5px;
-    margin-top: 60px;
+    margin-top: 6px;
     width: 90%;
     background-color: var(--primary-color);
     border-radius: 10px;
@@ -92,7 +129,7 @@
     flex-direction: column;
     align-items: center;
     border-radius: 10px;
-    margin-top: 40px;
+    margin-top: 6px;
     border: 2px solid var(--border-color);
 
     width: 90%;

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -151,16 +151,19 @@
     align-items: center;
 }
 
-.classification-count-content>img {
+.classification-count-content > img {
     height: 15px;
 }
 
-#classification-count-tooltip-message:hover {
+#classification-count-tooltip-message {
     transition: color 0.25s ease-in-out;
+}
+
+#classification-count-tooltip-message:hover {
     color: #abe7ad;
 }
 
-#classification-count-tooltip-message:hover+#classification-count-container {
+#classification-count-tooltip-message:hover + #classification-count-container {
     visibility: visible;
 }
 

--- a/src/public/pages/report/styles/reviewpanel.css
+++ b/src/public/pages/report/styles/reviewpanel.css
@@ -27,7 +27,7 @@
 
 @media (max-width: 1264px) and (min-width: 1000px) {
     #review-panel {
-        grid-template-rows: 82% 18%;
+        grid-template-rows: 88% 12%;
     }
 }
 
@@ -100,7 +100,7 @@
 
 }
 
-@media (max-width: 1126px) {
+@media (max-width: 1264px) {
     #review-panel-title {
         font-size: 27px;
     }


### PR DESCRIPTION
Feature addition to show engine evaluations.

I'm a backend developer, so the front-end code is a bit messy, but I did my best.
If you have any corrections or improvements, please leave a comment.

Thank you.

<img width="417" alt="image" src="https://github.com/WintrCat/freechess/assets/50986866/fa177104-67e4-410e-ae20-52f10d0187a5">
<img width="1281" alt="image" src="https://github.com/WintrCat/freechess/assets/50986866/0dc40f19-865f-4ee5-a4ae-21b9fe373662">
<img width="1725" alt="image" src="https://github.com/WintrCat/freechess/assets/50986866/dc67c46e-25c1-4f60-8cae-029341326d8b">