### PR TITLE
Fixed bug: eval bar graph

### DIFF
--- a/src/public/pages/report/scripts/board.ts
+++ b/src/public/pages/report/scripts/board.ts
@@ -254,7 +254,10 @@ function traverseMoves(moveCount: number) {
 
     let topLine = currentPosition?.topLines?.find(line => line.id == 1);
     lastEvaluation = topLine?.evaluation ?? { type: "cp", value: 0 }
-    drawEvaluationBar(topLine?.evaluation ?? { type: "cp", value: 0 }, boardFlipped);
+
+    const movedPlayer = getMovedPlayer();
+
+    drawEvaluationBar(topLine?.evaluation ?? { type: "cp", value: 0 }, boardFlipped, movedPlayer);
 
     updateClassificationMessage(positions[currentMoveIndex - 1], currentPosition);
     updateEngineSuggestions(currentPosition.topLines ?? []);
@@ -292,6 +295,10 @@ function traverseMoves(moveCount: number) {
         $<HTMLAudioElement>("#sound-fx-move").get(0)?.play();
     }
 }
+
+function getMovedPlayer() {
+    return (currentMoveIndex % 2) === 0 ? "black" : "white";
+ }
 
 $("#back-start-move-button").on("click", () => {
     traverseMoves(-Infinity);
@@ -338,7 +345,9 @@ $("#board").on("click", event => {
 $("#flip-board-button").on("click", () => {
     boardFlipped = !boardFlipped;
     
-    drawEvaluationBar(lastEvaluation, boardFlipped);
+    const movedPlayer = getMovedPlayer();
+
+    drawEvaluationBar(lastEvaluation, boardFlipped, movedPlayer);
     drawBoard(reportResults?.positions[currentMoveIndex]?.fen ?? startingPositionFen); 
     updateBoardPlayers();
 });
@@ -349,5 +358,5 @@ $("#suggestion-arrows-setting").on("input", () => {
 
 Promise.all(pieceLoaders).then(() => {
     drawBoard(startingPositionFen);
-    drawEvaluationBar(lastEvaluation, boardFlipped);
+    drawEvaluationBar(lastEvaluation, boardFlipped, "black");
 });

--- a/src/public/pages/report/scripts/evalbar.ts
+++ b/src/public/pages/report/scripts/evalbar.ts
@@ -1,59 +1,37 @@
-async function drawEvaluationBar(evaluation: Evaluation, boardFlipped: boolean) {
-    const evaluationBar = document.querySelector("#evaluation-bar") as SVGElement;
-    const whiteRect = document.querySelector("#white-rect") as SVGRectElement;
-    const blackRect = document.querySelector("#black-rect") as SVGRectElement;
-    const whiteEvalText = document.querySelector("#white-eval-text") as SVGTextElement;
-    const blackEvalText = document.querySelector("#black-eval-text") as SVGTextElement;
+const evaluationBar = document.querySelector("#evaluation-bar") as SVGElement;
+const whiteRect = document.querySelector("#white-rect") as SVGRectElement;
+const blackRect = document.querySelector("#black-rect") as SVGRectElement;
+const whiteEvalText = document.querySelector("#white-eval-text") as SVGTextElement;
+const blackEvalText = document.querySelector("#black-eval-text") as SVGTextElement;
 
-    const totalHeight = evaluationBar.clientHeight;
+const totalHeight = evaluationBar.clientHeight;
 
-    const blackHeight = Math.max(Math.min(totalHeight / 2 - evaluation.value / 3, totalHeight), 0);
-    const whiteHeight = Math.max(Math.min(totalHeight / 2 + evaluation.value / 3, totalHeight), 0);
-
-    let evaluationText: string;
-    if (evaluation.type === "cp") {
-        evaluationText = (Math.abs(evaluation.value) / 100).toFixed(1);
-        whiteRect.setAttribute("y", boardFlipped ? whiteHeight.toString() : blackHeight.toString());
-        whiteRect.setAttribute("height", boardFlipped ? blackHeight.toString() : whiteHeight.toString());
-        blackRect.setAttribute("height", boardFlipped ? whiteHeight.toString() : blackHeight.toString());
-    } else {
-        evaluationText = "M" + Math.abs(evaluation.value).toString();
-        if (evaluation.value === 0) {
-            evaluationText = "1-0";
-        }
-        if (!boardFlipped) {
-            if (evaluation.value >= 0) {
-
-                whiteRect.setAttribute("y", "0");
-                whiteRect.setAttribute("height", "730");
-                blackRect.setAttribute("height", "0");
-            } else {
-
-                whiteRect.setAttribute("y", "730");
-                whiteRect.setAttribute("height", "0");
-                blackRect.setAttribute("height", "730");
-
-            }
+function setEvalBarToWinner(winnerPlayer: "white" | "black") {
+    if (boardFlipped) {
+        if (winnerPlayer === "black") {
+            whiteRect.setAttribute("y", "0");
+            whiteRect.setAttribute("height", "730");
+            blackRect.setAttribute("height", "0");
         } else {
-            if (evaluation.value >= 0) {
-                whiteRect.setAttribute("y", "730");
-                whiteRect.setAttribute("height", "0");
-                blackRect.setAttribute("height", "730");
-
-            } else {
-
-                whiteRect.setAttribute("y", "0");
-                whiteRect.setAttribute("height", "730");
-                blackRect.setAttribute("height", "0");
-            }
+            whiteRect.setAttribute("y", "730");
+            whiteRect.setAttribute("height", "0");
+            blackRect.setAttribute("height", "730");
+        }
+    } else {
+        if (winnerPlayer === "black") {
+            whiteRect.setAttribute("y", "730");
+            whiteRect.setAttribute("height", "0");
+            blackRect.setAttribute("height", "730");
+        } else {
+            whiteRect.setAttribute("y", "0");
+            whiteRect.setAttribute("height", "730");
+            blackRect.setAttribute("height", "0");
         }
     }
-    whiteEvalText.textContent = evaluationText;
-    blackEvalText.textContent = evaluationText;
+}
 
-
-
-    if (evaluation.value >= 0) {
+function setEvalTextVisible(visiblePlayer: "white" | "black") {
+    if (visiblePlayer === "white") {
         whiteEvalText.setAttribute("visibility", boardFlipped ? "hidden" : "visible");
         blackEvalText.setAttribute("visibility", boardFlipped ? "visible" : "hidden");
         whiteEvalText.setAttribute("fill", boardFlipped ? "#fff" : "#000");
@@ -64,7 +42,49 @@ async function drawEvaluationBar(evaluation: Evaluation, boardFlipped: boolean) 
         whiteEvalText.setAttribute("fill", boardFlipped ? "#000" : "#fff");
         blackEvalText.setAttribute("fill", boardFlipped ? "#fff" : "#000");
     }
+}
 
+async function drawEvaluationBar(evaluation: Evaluation, boardFlipped: boolean, movedPlayer: "white" | "black") {
+    const blackHeight = Math.max(Math.min(totalHeight / 2 - evaluation.value / 3, totalHeight), 0);
+    const whiteHeight = Math.max(Math.min(totalHeight / 2 + evaluation.value / 3, totalHeight), 0);
+
+    let evaluationText: string;
+    let isCheckmated: boolean = false;
+    if (evaluation.type === "cp") {
+        evaluationText = (Math.abs(evaluation.value) / 100).toFixed(1);
+        whiteRect.setAttribute("y", boardFlipped ? whiteHeight.toString() : blackHeight.toString());
+        whiteRect.setAttribute("height", boardFlipped ? blackHeight.toString() : whiteHeight.toString());
+        blackRect.setAttribute("height", boardFlipped ? whiteHeight.toString() : blackHeight.toString());
+    } else {
+        // When checkmate steps 
+        evaluationText = "M" + Math.abs(evaluation.value).toString();
+        if (evaluation.value === 0) {
+            isCheckmated = true;
+            evaluationText = movedPlayer === "white" ? "1-0" : "0-1";
+        }
+
+        // Set eval bar for winner
+        if (evaluation.value > 0) {
+            setEvalBarToWinner("white");
+        } else if (evaluation.value < 0) {
+            setEvalBarToWinner("black");
+        } else if (evaluation.value === 0) {
+            setEvalBarToWinner(movedPlayer);
+        }
+    }
+    whiteEvalText.textContent = evaluationText;
+    blackEvalText.textContent = evaluationText;
+
+    // Set eval text visibility
+    if (isCheckmated) {
+        setEvalTextVisible(movedPlayer);
+    } else if (evaluation.value >= 0) {
+        setEvalTextVisible("white");
+    } else {
+        setEvalTextVisible("black");
+    }
+
+    // Fill evalbar with isBoardFlipped
     if (boardFlipped) {
         whiteEvalText.setAttribute("fill", "#fff");
         blackEvalText.setAttribute("fill", "#000");


### PR DESCRIPTION
fixed bug with EvalBar

when black winning with checkmate, EvalBar and text does not worked,

Before:
![before](https://github.com/WintrCat/freechess/assets/50986866/0346ecdb-dd7b-409f-940d-2508e7ffb1f2)

After:
![after](https://github.com/WintrCat/freechess/assets/50986866/6f97fef4-5a09-4410-83d4-3d54c68ad6bd)

If you have any corrections or improvements, please leave a comment.