### PR TITLE
Analyse button gray until game is selected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "freechess",
       "dependencies": {
         "chess.js": "^1.0.0-beta.6",
         "dotenv": "^16.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "freechess",
       "dependencies": {
         "chess.js": "^1.0.0-beta.6",
         "dotenv": "^16.3.1",

--- a/src/public/pages/report/scripts/loadgame.ts
+++ b/src/public/pages/report/scripts/loadgame.ts
@@ -33,7 +33,7 @@ function generateGameListing(game: Game): JQuery<HTMLDivElement> {
     listingContainer.attr("data-pgn", game.pgn);
     listingContainer.on("click", () => {
         $("#pgn").val(listingContainer.attr("data-pgn") || "");
-        $("#review-button").css({ "borderColor": "#4caf50", "box-shadow": "0px 5px 0px rgb(76, 175, 80, 0.6)" });
+        $("#review-button").removeClass("review-button-disabled");
         closeModal();
     });
 
@@ -222,6 +222,7 @@ loadTypeDropdown.on("input", () => {
     const isLong = selectedLoadType === "pgn" || selectedLoadType === "json";
     $("#pgn").css("display", isLong ? "block" : "none");
     $("#chess-site-username, #fetch-account-games-button").css("display", isLong ? "none" : "block");
+    $("#review-button").toggleClass("review-button-disabled", !isLong);
 
     $("#gameInputContainer").css("display", isLong ? "block" : "none");
     $("#gameInputContainer2").css("display", isLong ? "none" : "block");

--- a/src/public/pages/report/scripts/loadgame.ts
+++ b/src/public/pages/report/scripts/loadgame.ts
@@ -33,6 +33,7 @@ function generateGameListing(game: Game): JQuery<HTMLDivElement> {
     listingContainer.attr("data-pgn", game.pgn);
     listingContainer.on("click", () => {
         $("#pgn").val(listingContainer.attr("data-pgn") || "");
+        $("#review-button").css({ "borderColor": "#4caf50", "box-shadow": "0px 5px 0px rgb(76, 175, 80, 0.6)" });
         closeModal();
     });
 

--- a/src/public/pages/report/styles/reviewpanel.css
+++ b/src/public/pages/report/styles/reviewpanel.css
@@ -228,11 +228,16 @@
     color: white;
     text-shadow: 0px 1px 2px var(--border-color);
     width: 90%;
-    border: 2px solid gray;
+    border: 2px solid #4caf50;
     cursor: pointer;
     outline: none;
     user-select: none;
-    box-shadow: 0px 5px 0px rgb(128, 128, 128, 0.6);
+    box-shadow: 0px 5px 0px rgb(76, 175, 80, 0.6);
+}
+
+.review-button-disabled {
+    border: 2px solid gray !important;
+    box-shadow: 0px 5px 0px rgb(128, 128, 128, 0.6) !important;
 }
 
 #review-button:active {

--- a/src/public/pages/report/styles/reviewpanel.css
+++ b/src/public/pages/report/styles/reviewpanel.css
@@ -228,11 +228,11 @@
     color: white;
     text-shadow: 0px 1px 2px var(--border-color);
     width: 90%;
-    border: 2px solid #4caf50;
+    border: 2px solid gray;
     cursor: pointer;
     outline: none;
     user-select: none;
-    box-shadow: 0px 5px 0px rgb(76, 175, 80, 0.6);
+    box-shadow: 0px 5px 0px rgb(128, 128, 128, 0.6);
 }
 
 #review-button:active {


### PR DESCRIPTION
# Reasoning:
When I was using the site, I found myself clicking the 'Analyse' button before I had actually selected a game on chess.com

# Change:

On Chess.com and Lichess, the 'Analyse' button is gray until a game is selected, then it turns green again.

| No Game Selected | Game Selected |
| - | - |
| <img width="484" alt="image" src="https://github.com/WintrCat/freechess/assets/84303919/56adefa6-0521-444c-ae7e-36e3639212a2"> | <img width="479" alt="image" src="https://github.com/WintrCat/freechess/assets/84303919/d9730bd8-2df4-4d69-8c77-dcc3a0e02cb1"> |