### PR TITLE
style: add scroll to report card 

### DIFF
--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -295,14 +295,7 @@
                                 </h2>
                                 <span id="opening-name" class="white"></span>
                             </div>
-
-                            <div id="classification-count-tooltip-container">
-                                <div id="classification-count-tooltip-message">
-                                    * See your classifications
-                                </div>
-                                <div id="classification-count-container"></div>
-                            </div>
-
+                            <div id="classification-count-container"></div>
                             <div id="classification-message-container">
                                 <img
                                     id="classification-icon"

--- a/src/public/pages/report/index.html
+++ b/src/public/pages/report/index.html
@@ -293,6 +293,7 @@
                                         >
                                     </div>
                                 </h2>
+                                <span id="opening-name" class="white"></span>
                             </div>
 
                             <div id="classification-count-tooltip-container">
@@ -318,7 +319,6 @@
                                     Engine:
                                 </h2>
                             </div>
-                            <span id="opening-name" class="white"></span>
                         </div>
                     </div>
                     <div class="big-depth-container">

--- a/src/public/pages/report/styles/index.css
+++ b/src/public/pages/report/styles/index.css
@@ -4,9 +4,7 @@ body {
     width: 100vw;
 }
 
-
 @media only screen and (max-width: 1536px) {
-
     body {
         overflow-x: hidden;
     }
@@ -32,10 +30,6 @@ body {
         margin-top: 40px !important;
     }
 
-    #opening-name {
-        margin-bottom: 10px !important;
-    }
-
     #engine-suggestions {
         flex-direction: row !important;
         margin-top: 18px !important;
@@ -49,11 +43,9 @@ body {
     #board-outer-container {
         gap: 0 !important;
     }
-
 }
 
 @media only screen and (max-width: 1030px) {
-
     #board {
         width: 531.2px !important;
         height: 531.2px !important;
@@ -82,11 +74,9 @@ body {
     #load-type-dropdown {
         margin-top: -8px !important;
     }
-
 }
 
 @media only screen and (max-width: 960px) {
-
     body {
         overflow-x: hidden;
         overflow-y: auto;
@@ -135,10 +125,7 @@ body {
     #classification-message-container {
         margin-top: 40px;
     }
-
-
 }
-
 
 @media only screen and (max-width: 750px) {
     #board {
@@ -198,7 +185,6 @@ body {
 .white {
     color: white;
 }
-
 
 .footer {
     width: 100%;

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -93,9 +93,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-
     width: 90%;
-
     color: #4caf50;
 }
 
@@ -104,21 +102,18 @@
     font-style: italic;
     text-decoration: underline;
     font-weight: bold;
-
     cursor: pointer;
 }
 
 #classification-count-container {
     visibility: hidden;
     position: absolute;
-
     display: flex;
     align-items: center;
     border-radius: 10px;
     border: 2px solid var(--border-color);
     background-color: var(--primary-color);
     width: 60%;
-
     color: white;
     flex-direction: column;
     font-size: 13px;
@@ -126,10 +121,6 @@
 }
 
 @media (min-width: 1537px) {
-    #classification-count-tooltip-container {
-        margin-top: 40px;
-    }
-
     #classification-count-tooltip-message {
         font-size: 15px;
     }
@@ -140,10 +131,6 @@
 }
 
 @media (max-width: 1536px) {
-    #classification-count-tooltip-container {
-        margin-top: 40px;
-    }
-
     #classification-count-tooltip-message {
         font-size: 15px;
     }
@@ -154,10 +141,6 @@
 }
 
 @media (max-width: 380px) {
-    #classification-count-tooltip-container {
-        margin-top: 48px;
-    }
-
     #classification-count-tooltip-message {
         font-size: 11px;
     }
@@ -248,6 +231,7 @@
 .accuracyHolder {
     width: 100%;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     position: relative;
@@ -275,9 +259,6 @@
 */
 
 #opening-name {
-    position: absolute;
-    left: 5%;
-    top: 50px;
     width: 90%;
     border-radius: 10px;
     background-color: var(--primary-color);
@@ -285,6 +266,7 @@
     padding: 5px 10px;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+    margin-bottom: 10px;
 }
 
 @media (max-width: 1026px) {

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -100,47 +100,16 @@
 }
 
 #classification-count-container {
-    position: absolute;
-    display: none;
+    display: flex;
     align-items: center;
     border-radius: 10px;
     border: 2px solid var(--border-color);
     background-color: var(--primary-color);
-    width: 60%;
+    width: 90%;
     color: white;
     flex-direction: column;
     font-size: 13px;
     gap: 2px;
-}
-
-@media (min-width: 1537px) {
-    #classification-count-tooltip-message {
-        font-size: 15px;
-    }
-
-    #classification-count-container {
-        top: 112px;
-    }
-}
-
-@media (max-width: 1536px) {
-    #classification-count-tooltip-message {
-        font-size: 15px;
-    }
-
-    #classification-count-container {
-        top: 112px;
-    }
-}
-
-@media (max-width: 380px) {
-    #classification-count-tooltip-message {
-        font-size: 11px;
-    }
-
-    #classification-count-container {
-        top: 116px;
-    }
 }
 
 .classification-count-row {
@@ -158,18 +127,6 @@
 
 .classification-count-content > img {
     height: 15px;
-}
-
-#classification-count-tooltip-message {
-    transition: color 0.25s ease-in-out;
-}
-
-#classification-count-tooltip-message:hover {
-    color: #abe7ad;
-}
-
-#classification-count-tooltip-message:hover + #classification-count-container {
-    display: flex;
 }
 
 /*

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -31,15 +31,9 @@
     }
 }
 
-@media (max-width: 1000px) {
-    #report-cards {
-        max-height: 272px;
-    }
-}
-
 @media (max-width: 960px) {
     #report-cards {
-        max-height: 240px;
+        max-height: 245px;
     }
 }
 

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -12,6 +12,19 @@
     height: 100%;
 }
 
+#report-cards::-webkit-scrollbar {
+    width: 8px;
+}
+
+#report-cards::-webkit-scrollbar-thumb {
+    background: white;
+    border-radius: 12px;
+}
+
+#report-cards::-webkit-scrollbar-track {
+    background: transparent;
+}
+
 @media (max-width: 1537px) {
     #report-cards {
         max-height: 272px;

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -5,9 +5,29 @@
     display: none;
     flex-direction: column;
     align-items: center;
-
     width: 100%;
     position: relative;
+    overflow-y: auto;
+    max-height: 445px;
+    height: 100%;
+}
+
+@media (max-width: 1537px) {
+    #report-cards {
+        max-height: 272px;
+    }
+}
+
+@media (max-width: 1000px) {
+    #report-cards {
+        max-height: 272px;
+    }
+}
+
+@media (max-width: 960px) {
+    #report-cards {
+        max-height: 240px;
+    }
 }
 
 /*
@@ -41,7 +61,6 @@
     border-radius: 10px;
     padding: 3px 5px 3px 5px;
     font-size: 20px;
-
 }
 
 #white-accuracy {
@@ -50,7 +69,7 @@
 }
 
 #black-accuracy {
-    background-color: rgb(0, 0, 0, .6);
+    background-color: rgb(0, 0, 0, 0.6);
     color: white;
 }
 
@@ -75,7 +94,6 @@
 
     cursor: pointer;
 }
-
 
 #classification-count-container {
     visibility: hidden;
@@ -121,8 +139,6 @@
         top: 112px;
     }
 }
-
-
 
 @media (max-width: 380px) {
     #classification-count-tooltip-container {
@@ -200,7 +216,6 @@
     ENGINE SUGGESTIONS
 */
 #engine-suggestions {
-
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -223,7 +238,6 @@
     justify-content: center;
     align-items: center;
     position: relative;
-
 }
 
 .engine-suggestion {
@@ -232,7 +246,6 @@
     gap: 10px;
     margin: 5px;
     font-size: 16px;
-
 }
 
 .engine-suggestion b {

--- a/src/public/pages/report/styles/report.css
+++ b/src/public/pages/report/styles/report.css
@@ -100,9 +100,8 @@
 }
 
 #classification-count-container {
-    visibility: hidden;
     position: absolute;
-    display: flex;
+    display: none;
     align-items: center;
     border-radius: 10px;
     border: 2px solid var(--border-color);
@@ -170,7 +169,7 @@
 }
 
 #classification-count-tooltip-message:hover + #classification-count-container {
-    visibility: visible;
+    display: flex;
 }
 
 /*

--- a/src/public/pages/report/styles/reviewpanel.css
+++ b/src/public/pages/report/styles/reviewpanel.css
@@ -63,6 +63,7 @@
     align-items: center;
     position: relative;
     width: 100%;
+    height: calc(100% - 69px);
 }
 
 /*


### PR DESCRIPTION
To apply scrollbar on report-card i added `overflow-y: auto` and `maxHeight`
- i read this https://github.com/WintrCat/freechess/pull/47, you guys tried to show the classification under the review panel. but for some ui reason changed to tooltip
- i think it would be helpful to put classification information under review-panel not by tooltip

# Change:

| Before Apply Scrollbar  | After Apply Scrollbar |
| ------------- | ------------- |
| ![image](https://github.com/WintrCat/freechess/assets/30601503/08d185c7-8fcb-4a42-9073-9bd7ec9477ac)  |![image](https://github.com/WintrCat/freechess/assets/30601503/a66f60b5-c930-4083-9852-ba8750cf761e)  |
| ![image](https://github.com/WintrCat/freechess/assets/30601503/f1551f83-552e-4a3d-87b5-c68f8bb40db8)  | ![image](https://github.com/WintrCat/freechess/assets/30601503/70b382d7-7122-4d82-9677-82c2da4e17a5)  |


etc:
- moved opening-game under accuracyHolder and removed `position:absolute` on `opening-game`