### PR TITLE
Set default port to 5000 if not provided in the environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ app.get("/privacy", async (req, res) => {
     res.sendFile(path.resolve("src/public/pages/privacy/index.html"));
 });
 
-app.listen(process.env.PORT, () => {
-    console.log("Server running.");
+//if not port in env, set 5000
+const port = process.env.PORT == undefined? 5000: process.env.PORT
+
+app.listen(port, () => {
+    console.log("Server running on :", port);
 });


### PR DESCRIPTION
- Added logic to check if `process.env.PORT` is undefined.
- If the environment variable `PORT` is not defined, the server will default to port 5000.
- This ensures that the server can run locally with a default port if no environment variable is set.